### PR TITLE
Fixed Typo in Documentation, its a,b,c not a,b,v

### DIFF
--- a/doc/manual/src/chapters/030-navigator.md
+++ b/doc/manual/src/chapters/030-navigator.md
@@ -288,7 +288,7 @@ Consider the following HTML…
 
     <p title="a" class="a para">a</p>
     <p title="b" class="b para">b</p>
-    <p title="c" class="c para">v</p>
+    <p title="c" class="c para">c</p>
 
 The following assertions are valid…
 


### PR DESCRIPTION
Simple typo fix.
