### PR TITLE
GEB-207: Improve docs on interact block

### DIFF
--- a/doc/manual/src/chapters/030-navigator.md
+++ b/doc/manual/src/chapters/030-navigator.md
@@ -511,35 +511,81 @@ It's currently not possible with WebDriver to simulate the process of a user cli
     
     $("form").csvFile = "/path/to/my/file.csv"
 
-## Accessing the underlying WebElement objects
+## WebElements, Actions, and Interact Closures
 
-A Geb navigator object is built on top of a collection of WebDriver [WebElement][webelement-api] objects. It is possible to access the raw web elements via the following methods on navigator objects…
+A Geb navigator object is built on top of a collection of WebDriver [WebElement][webelement-api] objects. It is possible to access the contained WebElements via the following methods on navigator objects:
 
     WebElement firstElement()
     WebElement lastElement()
     Collection<WebElement> allElements()
 
-## Drag and Drop
+By using the methods of the WebDriver [Actions](http://selenium.googlecode.com/svn/trunk/docs/api/java/org/openqa/selenium/interactions/Actions.html) class with WebElements, complex user gestures can be emulated.
 
-Geb provides an interactions closure for performing 'human-like interaction' with the browser, by using the mouse or keyboard.
+### Using Actions
 
-	interact {
-		clickAndHold($('#element'))
-		moveByOffset(15, 15)
-		release()
-	}
+Create an Actions instance after obtaining the WebDriver driver:
 
-of course, this drag-and-drop operation could also be peformed using one of the composite 'convenience' methods the Actions api supports:
+    def actions = new Actions(driver)
 
-	interact {
-		dragAndDropBy($('#element'), 400, -150)
-	}
+Next, use methods of Actions to compose a series of UI actions, then call build() to create a concrete Action:
 
-In the example above, the element will be clicked, dragged 400 pixels towards the right, and then 150 pixels upwards before being released. Using a negative offset will simply move an element along the relevant axis in the opposite direction.
+    WebElement someItem = $('li.clicky').firstElement()
+    def shiftDoubleClickAction = actions.keyDown(Keys.SHIFT).doubleClick(someItem).keyUp(Keys.SHIFT).build()
 
-For a list of available interactions, see the documentation for the WebDriver [Actions](http://selenium.googlecode.com/svn/trunk/docs/api/java/org/openqa/selenium/interactions/Actions.html) class.
+Finally, call perform() to actually trigger the desired mouse or keyboard behavior:
 
-> Extracting the WebDriver element from your selector i.e. `$('#element').getElement(0)` is not necessary, as the interactions closure will always attempt do it for you. You can simply use navigators and content definition references as parameters for the `Actions` class methods.
+    shiftDoubleClickAction.perform()
 
-> Note that moving to arbritary locations with the mouse is currently not supported by the HTMLUnit driver, but moving directly to elements is.
+### Using Interact Closures
+
+To cut down on the amount of typing required, use an interact closure instead of using class Actions explicitly.  When using an interact closure, an Actions instance is implicitly created, built into an Action, and performed.
+As an added bonus, Geb Navigators can be passed directly to Actions methods within an interact closure.
+
+This interact closure performs the same work as the calls in the 'Using Actions' section:
+
+    interact {
+        keyDown(Keys.SHIFT)
+        doubleClick($('li.clicky'))
+        keyUp(Keys.SHIFT)
+    }
+
+This method creates code that is more readable than using Actions directly.
+
+For the full list of available interactions, see the documentation for the WebDriver [Actions](http://selenium.googlecode.com/svn/trunk/docs/api/java/org/openqa/selenium/interactions/Actions.html) class.
+
+### Interact Examples
+
+Interact closures (or Actions) can be used to perform behaviors that are more complicated than clicking buttons and anchors or typing in input fields.  Shift-double-clicking was demonstrated earlier.
+
+#### Drag and Drop
+
+clickAndHold, moveByOffset, and then release will drag and drop an element on the page.
+
+    interact {
+        clickAndHold($('#element'))
+        moveByOffset(400, -150)
+        release()
+    }
+
+Drag-and-dropping can also be accomplished using the dragAndDropBy convenience method from the Actions API:
+
+    interact {
+        dragAndDropBy($('#element'), 400, -150)
+    }
+
+In this particular example the element will be clicked then dragged 400 pixels to the right and 150 pixels upward before being released.
+
+> Note that moving to arbitrary locations with the mouse is currently not supported by the HTMLUnit driver, but moving directly to elements is.
+
+#### Control-Clicking
+
+Control-clicking several elements, such as items in a list, is performed the same way as shift-clicking.
+
+    interact {
+        keyDown(Keys.CONTROL)
+        click($('ul.multiselect li', text:'Order 1'))
+        click($('ul.multiselect li', text:'Order 2'))
+        click($('ul.multiselect li', text:'Order 3'))
+        keyUp(Keys.CONTROL)
+    }
 


### PR DESCRIPTION
http://jira.codehaus.org/browse/GEB-207

I've written some altered documentation that I hope will make the existence of the interact {} block capability clearer to readers.  I contrasted using interact blocks with using Actions directly and added more examples.

This is my first time creating a pull request, please forgive me if I violate some aspect of github etiquette.
