### PR TITLE
Even more reusable Page Object Model example.

### DIFF
--- a/doc/manual/src/chapters/040-pages.md
+++ b/doc/manual/src/chapters/040-pages.md
@@ -26,6 +26,11 @@ Here is the same script, utilising page objects…
             searchField { $("input[name=q]") }
             searchButton(to: GoogleResultsPage) { $("input[value='Google Search']") }
         }
+
+        void search(String searchTerm) {
+            searchField.value searchTerm
+            searchButton.click()
+        }
     }
 
     class GoogleResultsPage extends Page {
@@ -40,8 +45,7 @@ Here is the same script, utilising page objects…
     // Now the script
     Browser.drive {
         to GoogleHomePage
-        searchField().value "Chuck Norris"
-        searchButton().click()
+        search "Chuck Norris"
         at GoogleResultsPage
         resultLink(0).text().contains("Chuck")
     }


### PR DESCRIPTION
I've made this example even more reusable. It is a first full example of POM in manual so it's an opportunity to expose that pages should contain methods.

There is only one POM example with methods in chapter 9.2.1 (DynamicPage), which is way too late in manual and easy to overlook.
