### PR TITLE
css selectors can now escape . and # characters

### DIFF
--- a/module/geb-core/src/main/groovy/geb/navigator/CssSelector.groovy
+++ b/module/geb-core/src/main/groovy/geb/navigator/CssSelector.groovy
@@ -1,5 +1,6 @@
 package geb.navigator
 
+import groovy.json.StringEscapeUtils
 import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
 
@@ -159,12 +160,14 @@ class CssSelector {
 		int max = selector.length()
 		for (int index = 0; index < max; ++index) {
 			char character = selector.charAt(index)
-			if (index > 0 && (character == '.' || character == '#')) {
-				tokens << selector.substring(previous, index)
+			boolean escaped = index-1 >= 0 && selector[index-1]=="\\"
+			if (index > 0 && !escaped && (character == '.' || character == '#')) {
+				tokens << StringEscapeUtils.unescapeJava(selector.substring(previous, index))
 				previous = index
 			}
 		}
-		tokens << selector.substring(previous)
+		tokens << StringEscapeUtils.unescapeJava(selector.substring(previous))
+
 		return tokens
 	}
 }

--- a/module/geb-core/src/test/groovy/geb/navigator/CssSelectorSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/navigator/CssSelectorSpec.groovy
@@ -19,7 +19,7 @@ class CssSelectorSpec extends Specification {
 		browser.go(getClass().getResource("/test.html") as String)
 		onPage = browser.navigatorFactory.base
 	}
-	
+
 	def "selector type matching rules"() {
 		expect: selector.matches(element) == expectedMatch
 
@@ -53,6 +53,10 @@ class CssSelectorSpec extends Specification {
 		"blockquote#the_id.the_class p.last.wow.oh-yeah a  , div.totally p.rocks.your, div#socks a.off" | 0     | ["blockquote", "#the_id", ".the_class", " ", "p", ".last", ".wow", ".oh-yeah", " ", "a"]
 		"blockquote#the_id.the_class p.last.wow.oh-yeah a  , div.totally p.rocks.your, div#socks a.off" | 1     | ["div", ".totally", " ", "p", ".rocks", ".your"]
 		"blockquote#the_id.the_class p.last.wow.oh-yeah a  , div.totally p.rocks.your, div#socks a.off" | 2     | ["div", "#socks", " ", "a", ".off"]
+		"div#escapedPeriodInThe\\.Id"                                                                   | 0		| ["div", "#escapedPeriodInThe.Id"]
+		"#lots\\.Of\\.Periods\\.Id"                                                                     | 0		| ["#lots.Of.Periods.Id"]
+		".hash\\#Tags\\#Too"                                                                            | 0		| [".hash#Tags#Too"]
+		"#escapedBackslashesAre\\\\Ok.here\\\\ItIs"                                                     | 0		| ["#escapedBackslashesAre\\Ok", ".here\\ItIs"]
 	}
 
 	@Unroll("the CSS expression '#selector' should find #expectedIds")
@@ -71,6 +75,7 @@ class CssSelectorSpec extends Specification {
 		".aClassThatDoesNotExist" | []
 		"#anIdThatDoesNotExist"   | []
 		"#main div"               | ["article-1", null, "article-2", null, "article-3", null]
+		"input#domain\\.property" | ["domain.property"]
 	}
 
 }

--- a/module/geb-core/src/test/resources/test.html
+++ b/module/geb-core/src/test/resources/test.html
@@ -74,6 +74,7 @@
                         <legend>Search</legend>
                         <label for="keywords">Keywords:</label>
                         <input type="text" name="keywords" id="keywords" value="Enter keywords here"><br>
+                        <input type="text" name="domain.property" id="domain.property" value="Grails Fields Plugin Style Ids"><br>
                         <input type="radio" name="site" value="google" checked="checked" id="site-1"> <label for="site-1">Site #1</label>
                         <input type="radio" name="site" value="thisone" id="site-2"> <label for="site-2">Site #2</label><br>
                         <label><input type="radio" name="site" value="bing" id="site-3">Site #3</label><br>


### PR DESCRIPTION
this helps with things like element ids that happen to have special css characters in them. for example the grails fields plugin creates fields with ids in the form "domainClassName.poperty" that would previously trip up geb's selectors
