### PR TITLE
Adding section to manual about page object builder pattern

### DIFF
--- a/doc/manual/src/chapters/040-pages.md
+++ b/doc/manual/src/chapters/040-pages.md
@@ -636,3 +636,87 @@ Following shows an example usage:
     //browser.page set back to the PageWithFrames instance
 
 It is also possible to [specify a page to switch to for a page content that describes a frame][page-option].
+
+## Page Object builder pattern
+
+An additional way to work with page objects is a type-safe method that resembles a builder pattern.
+
+When using the page object builder style, instead of interacting with each content element directly from the test, page objects contain action methods that closely resemble the actions a user would perform if running the test manually.
+
+A sample test using standard Geb page objects:
+
+    to HomePage
+    loginButton.click()
+
+    username = "user1"
+    password = "password1"
+    loginButton.click()
+
+The same steps using the builder style:
+
+    HomePage homePage = to HomePage
+
+    LoginPage loginPage = homePage.clickLoginButton()
+
+    DashboardPage dashboardPage = loginPage.login("user1", "password1")
+
+Using the builder approach, each page object method encapsulates all the logic needed to perform a specific action - actions such as filling in forms, clicking links to new pages, dimissing modal dialogs etc. The action code could include waiting for the elements to be displayed, filling in field values, clicking a button, etc.
+
+In this example, the HomePage might look like:
+
+    class HomePage extends geb.Page {
+        static content = {
+            loginButton(to: LoginPage, wait: true) { $("#loginButton") }
+        }
+
+        LoginPage clickLoginButton() {
+            loginButton.click()
+
+            return browser.page
+        }
+    }
+
+and the LoginPage:
+
+    class LoginPage extends geb.Page {
+        static content = {
+            usernameField(wait: true) { $("#username") }
+            passwordField { $("#password") }
+            submitButton(to: DashboardPage) { $("#submit") }
+        }
+
+        DashboardPage login(String username, String password) {
+            usernameField.value(username)
+            passwordField.value(password)
+
+            submitButton.click()
+
+            return browser.page
+        }
+    }
+
+The encapsulated page object actions are especially handy when interacting with the content requires automation-specific code, such as waiting for elements to be displayed. One example of this is working with a modal dialog where we want the test to wait for the modal to be displayed, click the confirm button, then wait for the modal to close. We can capture all that code in the page object and avoid needing to repeat it in every test that interacts with the modal. And if the dialog itself changes, we only have a single spot in the test codebase to update.
+
+    class SaveConfirmationModal extends geb.page {
+        static content = {
+            confirmButton(to: ResultsPage) { $("#confirmButton") }
+        }
+
+        ResultsPage confirm() {
+            waitFor { confirmButton.displayed }
+
+            confirmButton.click()
+
+            waitFor { !confirmButton.displayed }
+
+            return browser.page
+        }
+    }
+
+Each page object action also returns a reference to the current page by returning `browser.page`. That allows the test to easily keep a reference to the current page.
+
+Returning the current page also allows the test to chain page calls together for more concise test code that resembles a builder:
+
+    DashboardPage dashboardPage = to(HomePage).clickLoginButton().login("user1", "password1")
+
+Using the builder style and creating these individual page object actions is a little more work up front, but it can pay dividends in the long run with test code that is easier to read and simpler to maintain.


### PR DESCRIPTION
I discussed this page object builder method at my Gr8conf presentation on Geb last week and Luke asked if I would add a section in the Geb manual about it. 

If I should make any changes to this section, just let me know.
