### PR TITLE
Adding the ability to pass a page object into the withWindow method 

### DIFF
--- a/module/geb-core/src/test/groovy/geb/WindowHandlingSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/WindowHandlingSpec.groovy
@@ -130,6 +130,33 @@ class WindowHandlingSpec extends GebSpecWithServer {
 		2              | { title in [windowTitle(1), windowTitle(2)] }
 	}
 
+	@Unroll
+	def "withWindow block closure is called in the context of the page passed as the 'page' option"() {
+		given:
+		go MAIN_PAGE_URL
+		page WindowHandlingSpecMainPage
+		allWindowsOpened()
+
+		when:
+		withWindow(page: WindowHandlingSpecNewWindowPage, specification) {
+			assert page.getClass() == WindowHandlingSpecNewWindowPage
+		}
+
+		then:
+		page.getClass() == WindowHandlingSpecMainPage
+
+		where:
+		specification << [
+			{ true },
+			{ title == windowTitle() },
+			{ title in [windowTitle(1), windowTitle(2)] },
+			windowName(1),
+			windowName(2)
+		]
+	}
+
+
+
 	@Unroll("ensure withNewWindow throws an exception when: '#message'")
 	def "ensure withNewWindow throws exception if there was none or more than one windows opened"() {
 		when:


### PR DESCRIPTION
Like the withNewWindow method, withWindow should allow for the inclusion of a page object to better test and manipulate child windows. Currently, one has to either manually control which page object the browser uses or manually traverse the child window to get to objects within the step definition.
