### PR TITLE
Add support for Grails random HTTP/HTTPS port.

### DIFF
--- a/integration/geb-grails/scripts/_Events.groovy
+++ b/integration/geb-grails/scripts/_Events.groovy
@@ -130,6 +130,17 @@ eventTestPhaseStart = { phaseName ->
 	}
 }
 
+eventTestPhasePrepared = { phaseName ->
+    if (phaseName == 'functional') {
+        //reset the base URL based on actual server port (starting with Grails 2.2.5, 2.3.1)
+        //this event gets called after Tomcat has started and actual local port as been assigned
+        def buildAdapterClass = loadGebBuildAdapterClass()
+        def baseUrl = argsMap["baseUrl"] ?:
+            "http://${serverHost ?: 'localhost'}:${getServerPort()}${serverContextPath == "/" ? "" : serverContextPath}/"
+        System.setProperty(buildAdapterClass.BASE_URL_PROPERTY_NAME, baseUrl)
+    }
+}
+
 // Just upgrade plugins without user input when building this plugin
 // Has no effect for clients of this plugin
 if (grailsAppName == 'geb') {


### PR DESCRIPTION
Listen to the new test event that occurs after the test phase is
prepared and get the actual local server port if necessary.

Supports the changes made in https://github.com/grails/grails-core/commit/e4c63c60c907766d68205e5156d15d9e3318631b and https://github.com/grails-plugins/grails-tomcat-plugin/commit/19369183876e9aa590d3bc48f6b4d6f5c51c1899
