### PR TITLE
Fix some typos in the manual

### DIFF
--- a/doc/manual/src/chapters/020-browser.md
+++ b/doc/manual/src/chapters/020-browser.md
@@ -296,7 +296,7 @@ If you pass any truly value as `close` option then all matching windows will be 
 
 Default value: `null`
 
-If you pass a class that extends `Page` as `page` option then browser's page will be set to that value before executing the closure passed as the last argument and will be reverted to it's original value afterwards.
+If you pass a class that extends `Page` as `page` option then browser's page will be set to that value before executing the closure passed as the last argument and will be reverted to its original value afterwards.
 
 ### Switching context to newly opened windows
 
@@ -324,7 +324,7 @@ If you pass any truly value as `close` option then the newly opened window will 
 
 Default value: `null`
 
-If you pass a class that extends `Page` as `page` option then browser's page will be set to that value before executing the closure passed as the last argument and will be reverted to it's original value afterwards.
+If you pass a class that extends `Page` as `page` option then browser's page will be set to that value before executing the closure passed as the last argument and will be reverted to its original value afterwards.
 
 ##### wait
 

--- a/doc/manual/src/chapters/080-javascript.md
+++ b/doc/manual/src/chapters/080-javascript.md
@@ -268,7 +268,7 @@ A side effect of the way that this is implemented is that we aren't able to defi
 
 ### About prompt()
 
-Geb does not provide any support for prompt() due to it's infrequent and generally discouraged use.
+Geb does not provide any support for prompt() due to its infrequent and generally discouraged use.
 
 ## jQuery Integration
 

--- a/doc/manual/src/chapters/110-testing.md
+++ b/doc/manual/src/chapters/110-testing.md
@@ -6,7 +6,7 @@ Geb provides first class support for functional web testing via integration with
 
 The Spock, JUnit and TestNG integrations work fundamentally the same way. They provide subclasses that setup a [browser][browser-api] instance that all method calls and property accesses/references resolve against via Groovy's `methodMissing` and `propertyMissing` mechanism.
 
-> Recall that the browser instance also forwards any method calls or property accesses/references that it can't handle to it's current page object, which helps to remove a lot of noise from the test.
+> Recall that the browser instance also forwards any method calls or property accesses/references that it can't handle to its current page object, which helps to remove a lot of noise from the test.
 
 Consider the following Spock spec…
 


### PR DESCRIPTION
Replace "it's" by "its" where appropriate.
