### PR TITLE
Add config option to enable waiting by default on all content elements

### DIFF
--- a/doc/manual/src/chapters/060-configuration.md
+++ b/doc/manual/src/chapters/060-configuration.md
@@ -148,6 +148,16 @@ Defaults can be specified via:
 
 Both values are optional and in seconds. If unspecified, the values of `5` for `timeout` and `0.1` for `retryInterval`.
 
+#### Enabled by Default
+
+You can turn on waiting on all elements by default. This is equivalent to adding `(wait: true)` to all page object content elements.
+
+    waiting {
+        enabledByDefault = true
+    }
+
+If you want to disable waiting on a specific element, set `(wait: false)` on an individual page object content element will override this default.
+
 #### Presets
 
 Presets can be specified via:

--- a/module/geb-core/src/main/groovy/geb/Configuration.groovy
+++ b/module/geb-core/src/main/groovy/geb/Configuration.groovy
@@ -81,7 +81,7 @@ class Configuration {
 		
 		new Wait(timeout, retryInterval)
 	}
-	
+
 	Wait getDefaultWait() {
 		new Wait(getDefaultWaitTimeout(), getDefaultWaitRetryInterval())
 	}
@@ -90,7 +90,7 @@ class Configuration {
 		new Wait(timeout, getDefaultWaitRetryInterval())
 	}
 
-	Wait getWaitForParam(waitingParam) {
+	Wait parseWaitForParam(waitingParam) {
 		if (waitingParam == true) {
 			defaultWait
 		} else if (waitingParam instanceof CharSequence) {
@@ -116,6 +116,20 @@ class Configuration {
 	}
 
 	/**
+	 * Parses and returns the waiting value if the param is not null or returns the default wait value
+	 * if waiting is enabled by default with the config value.
+	 */
+	Wait getWaitForParam(waitingParam) {
+		if (waitingParam != null) {
+			parseWaitForParam(waitingParam)
+		} else if (getWaitEnabledByDefault()) {
+			defaultWait
+		} else {
+			null
+		}
+	}
+
+	/**
 	 * Updates the {@code waiting.timeout} config entry.
 	 *
 	 * @see #getDefaultWaitTimeout()
@@ -131,6 +145,13 @@ class Configuration {
 	 */
 	Double getDefaultWaitTimeout() {
 		readValue(rawConfig.waiting, 'timeout', Wait.DEFAULT_TIMEOUT)
+	}
+
+	/**
+	 * Whether or not all content elements wait by default
+	 */
+	boolean getWaitEnabledByDefault() {
+		readValue(rawConfig.waiting, 'enabledByDefault', false)
 	}
 
 	/**
@@ -152,7 +173,7 @@ class Configuration {
 	}
 
 	Wait getAtCheckWaiting() {
-		getWaitForParam(rawConfig.atCheckWaiting)
+		parseWaitForParam(rawConfig.atCheckWaiting)
 	}
 
 	void setAtCheckWaiting(Object waitForParam) {

--- a/module/geb-core/src/test/groovy/geb/conf/WaitingConfigurationSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/conf/WaitingConfigurationSpec.groovy
@@ -130,4 +130,50 @@ class WaitingConfigurationSpec extends Specification {
 		getWaitPreset("slow") == new Wait(30, 1)
 		getWaitPreset("partial") == new Wait(3, 5)
 	}
+
+	def "when 'wait' is true should get default wait"() {
+		given:
+		userConf = """
+			waiting {
+				timeout = 30
+			}
+		"""
+
+		when:
+		Wait waitForValue = getWaitForParam(true)
+
+		then:
+		assert waitForValue.timeout.toInteger() == 30
+	}
+
+	def "when 'wait' is false should get null wait"() {
+		given:
+		userConf = """
+			waiting {
+				timeout = 30
+			}
+		"""
+
+		when:
+		Wait waitForValue = getWaitForParam(false)
+
+		then:
+		assert waitForValue == null
+	}
+
+	def "when default wait enabled should get default wait value"() {
+		given:
+		userConf = """
+			waiting {
+				timeout = 30
+				enabledByDefault = true
+			}
+		"""
+
+		when:
+		Wait waitForValue = getWaitForParam(null)
+
+		then:
+		assert waitForValue?.timeout?.toInteger() == 30
+	}
 }

--- a/module/geb-core/src/test/groovy/geb/waiting/WaitingContentSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/waiting/WaitingContentSpec.groovy
@@ -53,6 +53,18 @@ class WaitingContentSpec extends WaitingSpec {
 		then:
 		content.text() == "a"
 	}
+
+	def "waiting by default is enabled"() {
+		given:
+		gebConfScript = 'geb/conf/waiting-enabled-by-default-config.groovy'
+		resetBrowser()
+
+		when:
+		content
+
+		then:
+		content.text() == "a"
+	}
 	
 	def "wait timeout"() {
 		when:
@@ -142,7 +154,6 @@ class WaitingContentSpec extends WaitingSpec {
 		then:
 		waitContent.text() == "a"
 	}
-
 }
 
 class DynamicallySpecifiedContentPage extends Page {

--- a/module/geb-core/src/test/resources/geb/conf/waiting-enabled-by-default-config.groovy
+++ b/module/geb-core/src/test/resources/geb/conf/waiting-enabled-by-default-config.groovy
@@ -1,0 +1,4 @@
+waiting {
+    timeout = 5
+    enabledByDefault = true
+}


### PR DESCRIPTION
On my current project our CI server is running many builds in parallel and often gets overloaded, which slows down our Geb tests. To guard against timing failures due to slow page loads on our CI server, I've had to add (wait: true) to all of our page object elements. 

Rather than needing to enable waiting on each individual page object element, I wanted to be able to enable waiting by default via a config value in the GebConfig file.
