### PR TITLE
 	Updated documentation to refer to correct configuration required to use geb-saucelabs

### DIFF
--- a/doc/manual/src/chapters/111-sauce-labs.md
+++ b/doc/manual/src/chapters/111-sauce-labs.md
@@ -32,6 +32,7 @@ Assuming you're using the snippet from the example above in your `GebConfig.groo
 The second part of SauceLabs integration is the `geb-saucelabs` Gradle plugin. You can use it in your Gradle build to easily create multiple `Test` tasks that will have `geb.sauce.browser` property set.  The value of that property can be then passed in configuration file to [SauceLabsDriverFactory](#saucelabsdriverfactory) as the ”browser specification“. What follows is a typical usage example:
 
 	apply plugin: "geb-saucelabs" //1
+	apply plugin: "project-report"
 
 	buildscript { //2
 		repositories {


### PR DESCRIPTION
We made the following changes to the sample build.gradle listed on http://www.gebish.org/manual/0.9.2/build-integrations.html
- include the project-report plugin 
- remove the tasks closure
- include a tasks.withType(Test) closure which sets the destination directories

See http://stackoverflow.com/questions/22602959/gradle-geb-saucelabs-plugin/22759012#22759012 for further information
