### PR TITLE
removed setBuildFile method

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,14 +14,8 @@ include "module:geb-core",
 
 rootProject.name = 'geb'
 
-def setBuildFile(project) {
-	project.buildFileName = "${project.name}.gradle"
-	project.children.each {
-		setBuildFile(it)
-	}
-}
+rootProject.buildFileName = "${rootProject.name}.gradle"
 
-setBuildFile(rootProject)
 rootProject.children.each {
-	setBuildFile(it)
+	it.buildFileName = "${it.name}.gradle"
 }


### PR DESCRIPTION
Unless the children projects have projects of their own, I don't think the setBuildFile method is necessary.
