### PR TITLE
missing LanguageOptions element

### DIFF
--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -37,7 +37,16 @@ idea {
 						</copyright>
 					"""))
 					def templateLanguageOptions = copyrightManager.LanguageOptions.find { it.'@name' == '__TEMPLATE__' }
-					templateLanguageOptions.option.find { it.'@name' == 'addBlankAfter' }.@value = false
+					if(templateLanguageOptions == null) {
+						copyrightManager.append(new XmlParser().parseText("""					
+							<LanguageOptions name="__TEMPLATE__">
+								<option name="addBlankAfter" value="false" />
+							</LanguageOptions>
+						"""))
+					}
+					else {
+						templateLanguageOptions.option.find { it.'@name' == 'addBlankAfter' }.@value = false
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the following build error...

FAILURE: Build failed with an exception.
- Where:
  Script '...\geb\gradle\idea.gradle' line: 40
- What went wrong:
  Execution failed for task ':ideaProject'.
  
  > Cannot get property 'option' on null object
