### PR TITLE
Update geb-saucelabs plugin to use Sauce Connect 4

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -16,9 +16,16 @@
 
 apply plugin: 'groovy'
 
+repositories {
+    mavenCentral()
+    maven { url "http://repository-saucelabs.forge.cloudbees.com/release" }
+}
+
 dependencies {
 	compile localGroovy()
 	compile gradleApi()
+    compile "com.saucelabs:ci-sauce:1.81"
+
 }
 
 sourceSets {

--- a/geb.gradle
+++ b/geb.gradle
@@ -31,6 +31,7 @@ allprojects { project ->
 		seleniumVersion = "2.43.1"
 		groovyVersion = "2.3.6"
 		spockVersion = "0.7-groovy-2.0"
+        sauceVersion = "1.81"
 
 		spockDependency = dependencies.create("org.spockframework:spock-core:$spockVersion") {
 			exclude module: "groovy-all"
@@ -44,6 +45,8 @@ allprojects { project ->
 		jettyDependency = "org.mortbay.jetty:jetty:6.1.21"
 
 		groovyDependency = "org.codehaus.groovy:groovy-all:$groovyVersion"
+
+        sauceDependency = "com.saucelabs:ci-sauce:$sauceVersion"
 
 		repositories {
 			mavenCentral()

--- a/integration/geb-gradle/geb-gradle.gradle
+++ b/integration/geb-gradle/geb-gradle.gradle
@@ -1,8 +1,15 @@
 apply plugin: 'groovy'
 
+repositories {
+    mavenCentral()
+    maven { url "http://repository-saucelabs.forge.cloudbees.com/release" }
+}
+
 dependencies {
 	compile localGroovy()
 	compile gradleApi()
+
+    compile sauceDependency
 }
 
 modifyPom { pom ->

--- a/integration/geb-gradle/src/main/groovy/geb/gradle/saucelabs/SauceAccount.groovy
+++ b/integration/geb-gradle/src/main/groovy/geb/gradle/saucelabs/SauceAccount.groovy
@@ -20,12 +20,22 @@ import org.gradle.api.tasks.testing.Test
 class SauceAccount {
 	public static final String USER_ENV_VAR = "GEB_SAUCE_LABS_USER"
 	public static final String ACCESS_KEY_ENV_VAR = "GEB_SAUCE_LABS_ACCESS_PASSWORD"
+	public static final String SAUCE_CONNECT_OPTS_ENV_VAR = "GEB_SAUCE_LABS_OPTIONS"
+	public static final String SAUCE_CONNECT_PORT_ENV_VAR = "GEB_SAUCE_LABS_PORT"
 
+    /** The Sauce Labs username to use for the Sauce Connect instance. */
 	String username
+    /** The Sauce Labs access key to use for the Sauce Connect instance. */
 	String accessKey
+    /** The Sauce Labs command line options to be supplied when launching Sauce Connect. */
+    String options
+    /** The port that Sauce Connect should be launched on. */
+    Integer port = 4445
 
 	void configure(Test test) {
 		test.environment(USER_ENV_VAR, username)
 		test.environment(ACCESS_KEY_ENV_VAR, accessKey)
+		test.environment(SAUCE_CONNECT_OPTS_ENV_VAR, options)
+		test.environment(SAUCE_CONNECT_PORT_ENV_VAR, port)
 	}
 }

--- a/module/geb-core/geb-core.gradle
+++ b/module/geb-core/geb-core.gradle
@@ -14,7 +14,6 @@ dependencies {
 	compile project(":module:geb-ast")
 	compile project(":module:geb-waiting")
 
-	sauceConnect "com.saucelabs:sauce-connect:3.1.32"
 }
 
 test {


### PR DESCRIPTION
This pull request includes changes to update the geb-saucelabs plugin to use Sauce Connect 4.

Sauce Connect 4 is a C-based binary distribution (the previous version was Java based), and the zip files relevant to each supported operating system are currently included within the [Sauce CI helper library](https://github.com/saucelabs/ci-sauce).

This change uses the SauceConnectFourManager class to extract the Sauce Connect zip file which is applicable to the current operating system from the ci-sauce.jar file to the current working directory, and return the command line arguments required to launch Sauce Connect.

The change also allows users to supply extra options to the Sauce Connect process, as well as changing the port that Sauce Connect is launched on.

The previous requirement for users to specify the Sauce Connect jar file location is not needed as part of these changes.

Please let me know if there are any problems with the change - I had to include the ci-sauce dependency in several of the build.gradle file in order to get everything compiling.
