### PR TITLE
To fix an issue of creating two instances of new Page when calling Browser.to(Class) method.

### DIFF
--- a/module/geb-core/src/main/groovy/geb/Browser.groovy
+++ b/module/geb-core/src/main/groovy/geb/Browser.groovy
@@ -445,12 +445,12 @@ class Browser {
 	 * @see geb.Page#to(java.util.Map, java.lang.Object)
 	 */
 	public <T extends Page> T to(Map params, Class<T> pageType, Object[] args) {
-		via(params, pageType, args)
+		def page = via(params, pageType, args)
 		try {
-			at(pageType)
+			doAt(page)
 		} catch (UndefinedAtCheckerException e) {
 			// that's okay, we don't want to force users to define at checkers unless they explicitly use "at"
-			createPage(pageType)
+			page
 		}
 	}
 


### PR DESCRIPTION
Given we have some page classes:

```
abstract class BasePage extends Page {
    def context = [:]

    @Override
    void onUnload(Page newPage) {
        newPage.context << context
    }
}

class FirstPage extends BasePage {}

class SecondPage extends BasePage {
    static at = {
        context.prop1 == label1.text()
        context.prop2 == label2.text()
    }
    static content = {
        label1 {...}
        label2 {...}
    }
}
```

And this is test case as below:

```
When:
    to FirstPage

And:
    context << [prop1: "abc", prop2: "123"]
    // do something

And:
    to SecondPage
```

The last step will fail in the "At Checker" of SecondPage.

The root cause is that the Browser.to(Class) will create two different instances of new Page class.
