### PR TITLE
Fix wrong issue link for new 'focused()' method

### DIFF
--- a/doc/manual/src/docs/asciidoc/140-project.adoc
+++ b/doc/manual/src/docs/asciidoc/140-project.adoc
@@ -98,7 +98,7 @@ No changes have been made, yet.
 * Added form control module for month inputs. [issue:552[]]
 * Added form control module for range inputs. [issue:551[]]
 * Added form control module for week inputs. [issue:553[]]
-* Added `focused()` method on `Navigable` which obtains a `Navigator` wrapping the active (focused) `WebElement`. [issue:553[]]
+* Added `focused()` method on `Navigable` which obtains a `Navigator` wrapping the active (focused) `WebElement`. [issue:546[]]
 * Ability to require at checkers to be defined even for pages that are implicitly at checked. [issue:541[]]
 
 ==== Fixes


### PR DESCRIPTION
Should point to #546, not to #553