### PR TITLE
Update README and links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,17 +86,19 @@ When a pull request is send it triggers a CI build to verify the the test and qu
 
 ## Proposing new features
 
-If you would like to implement a new feature, please [raise an issue](https://github.com/geb/issues/issues) before sending a pull request so the feature can be discussed.
+If you would like to implement a new feature, please [raise an issue](https://github.com/geb/geb/issues) before sending a pull request so the feature can be discussed.
 This is to avoid you spending your valuable time working on a feature that the project developers are not willing to accept into the codebase.
 
 ## Fixing bugs
 
-If you would like to fix a bug, please [raise an issue](https://github.com/geb/issues/issues) before sending a pull request so it can be discussed.
+If you would like to fix a bug, please [raise an issue](https://github.com/geb/geb/issues) before sending a pull request so it can be discussed.
 If the fix is trivial or non controversial then this is not usually necessary.
 
-## Development Mailing List
+## Community and Support
 
-If you want to do some work on Geb and want some help, you can join the `geb-dev@googlegroups.com` mailing list via [Google Groups](https://groups.google.com/d/forum/geb-dev).
+If you want to do some work on Geb and want some help, you can join us in 
+ [the GitHub Discussions forum](https://github.com/geb/geb/discussions) or in 
+ the `#geb` channel on [the Groovy Slack workspace](https://groovycommunity.com).
 
 ## Licensing and attribution
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://circleci.com/gh/geb/geb/tree/master.svg?style=shield&circle-token=36ce4eb346f11ba916707d493b3f226bd5c9a5ec)](https://circleci.com/gh/geb/workflows/geb/tree/master)
+[![Build Status](https://circleci.com/gh/geb/geb/tree/master.svg?style=shield)](https://circleci.com/gh/geb/workflows/geb/tree/master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.gebish/geb-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.gebish/geb-core)
 [![GitHub contributors](https://img.shields.io/github/contributors/geb/geb.svg)](https://github.com/geb/geb/graphs/contributors/)
 
@@ -12,5 +12,7 @@ Please see [CONTRIBUTING.md](https://github.com/geb/geb/blob/master/CONTRIBUTING
 
 ## Submitting issues
 
-If you'd like to submit an issue against Geb then please use [the issue tracker for geb/issues Github project](https://github.com/geb/issues/issues).
-Please avoid submitting usage questions as issues and use [the user mailing list](https://groups.google.com/forum/#!forum/geb-user) instead.
+If you'd like to submit an issue against Geb then please use [the issue tracker](https://github.com/geb/geb/issues). 
+
+For help and other discussions join us in [the GitHub Discussions forum](https://github.com/geb/geb/discussions) or
+in the `#geb` channel on [the Groovy Slack workspace](https://groovycommunity.com).

--- a/doc/manual/src/docs/asciidoc/140-project.adoc
+++ b/doc/manual/src/docs/asciidoc/140-project.adoc
@@ -8,9 +8,10 @@ The API reference can be found link:api/index.html[here].
 
 == Support &amp; development
 
-Support for Geb is offered on the link:mailto:geb-user@googlegroups.com[geb-user@googlegroups.com] mailing list, which can be subscribed to link:https://groups.google.com/forum/#!forum/geb-user[here].
-
-Ideas and new features for Geb can be discussed on the link:mailto:geb-dev@googlegroups.com[geb-dev@googlegroups.com] mailing list, which can be subscribed to link:https://groups.google.com/d/forum/geb-dev[here].
+Support for Geb is offered on 
+https://github.com/geb/geb/discussions[the GitHub Discussions forum] 
+or in the `#geb` channel on 
+https://groovycommunity.com[the Groovy Slack workspace].
 
 == Credits
 


### PR DESCRIPTION
Some basic updates to the main README and links section of the site. 

Updates the issue tracker to point at the core Geb issue tracker (this project) rather than the geb/issues project.

Updates pointers to the mailing lists towards the GitHub Discussions and Groovy Slack instead. 