### PR TITLE
Fix codenarc space error

### DIFF
--- a/doc/manual-snippets/real-browser/src/test/groovy/javascript/JQuerySupportSpec.groovy
+++ b/doc/manual-snippets/real-browser/src/test/groovy/javascript/JQuerySupportSpec.groovy
@@ -36,7 +36,7 @@ class JQuerySupportSpec extends GebSpecWithServerUsingJavascript {
             } else {
                 response.contentType = ContentType.TEXT_HTML.toString()
                 response.writer << '''
-                    //tag::html[]
+                    // tag::html[]
                     <html>
                         <head>
                             <script type="text/javascript" src="/js/jquery-2.1.4.min.js"></script>
@@ -53,7 +53,7 @@ class JQuerySupportSpec extends GebSpecWithServerUsingJavascript {
                             <div id="b" style="display:none;"><a href="http://www.gebish.org">Geb!</a></div>
                         </body>
                     </html>
-                    //end::html[]
+                    // end::html[]
                 '''
             }
         }

--- a/module/geb-core/src/test/groovy/geb/PageOrientedSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/PageOrientedSpec.groovy
@@ -599,7 +599,7 @@ class PageWithAtCheckerThrowingException extends Page {
 }
 
 class PageWithAtCheckerReturningFalse extends Page {
-    //this circumvents implicit assertion AST transformation
+    // this circumvents implicit assertion AST transformation
     static atChecker = { false }
     static at = atChecker
 }

--- a/module/geb-core/src/test/groovy/geb/navigator/EdgeIncompatibleSelectControlSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/navigator/EdgeIncompatibleSelectControlSpec.groovy
@@ -24,7 +24,7 @@ import geb.test.browsers.Firefox
 import geb.test.browsers.InternetExplorer
 import geb.test.browsers.Safari
 
-//Some functionality around multiselect seems not to work in Edge
+// Some functionality around multiselect seems not to work in Edge
 @Chrome
 @Firefox
 @InternetExplorer


### PR DESCRIPTION
I noticed that codenarc was failing in CircleCI due to SpaceAfterCommentDelimiter violations. This was a quick fix with a regex, so I'm going to just merge it.