### PR TITLE
Make test step add codenarc and doc site build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build and test
+name: Build, test, and quality check
 
 on: [push, pull_request]
 
@@ -40,7 +40,7 @@ jobs:
       - name: Check firefox version
         run: /usr/bin/firefox --version
       - name: Build and run tests
-        run: ./gradlew --no-daemon --no-build-cache test
+        run: ./gradlew -Pci --no-daemon --no-build-cache check
         timeout-minutes: 60
       - name: Upload reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This makes the base test step cover the same ground as the CircleCI build by adding the `ci` property and using `check`, not just `test`. The main difference is that this will run CodeNarc and copy reports from submodules into the root directory.

It seemed reasonable to me to run these all in the same step.