### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -28,7 +28,7 @@ jobs:
         java: [17, 21] # TODO add 11
     runs-on: ubuntu-latest
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -24,7 +24,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -21,7 +21,7 @@ def env = System.getenv()
 boolean isCI = env.CI || env.TEAMCITY_VERSION || env.GITHUB_ACTIONS
 
 develocity {
-    server = "https://ge.apache.org"
+    server = "https://develocity.apache.org"
     allowUntrustedServer = false
 
     buildScan {

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -23,6 +23,7 @@ boolean isCI = env.CI || env.TEAMCITY_VERSION || env.GITHUB_ACTIONS
 develocity {
     server = "https://develocity.apache.org"
     allowUntrustedServer = false
+    projectId = "groovy-geb"
 
     buildScan {
         uploadInBackground = !isCI

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ plugins {
     // Check https://gradle.com/enterprise/releases with new versions. GE plugin version should not lag behind Gradle version, but before
     // updating this, check the compatibility from https://docs.gradle.com/enterprise/compatibility/#develocity_compatibility and https://develocity.apache.org/scans.
     id "com.gradle.develocity" version "3.18.2"
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
 apply from: 'gradle/build-scans.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ plugins {
     id "org.kordamp.gradle.oci-build-cache" version "0.6.0"
     id "org.gradle.toolchains.foojay-resolver" version "0.8.0"
     // Check https://gradle.com/enterprise/releases with new versions. GE plugin version should not lag behind Gradle version, but before
-    // updating this, check the compatibility from https://docs.gradle.com/enterprise/compatibility/#develocity_compatibility and https://ge.apache.org/scans.
+    // updating this, check the compatibility from https://docs.gradle.com/enterprise/compatibility/#develocity_compatibility and https://develocity.apache.org/scans.
     id "com.gradle.develocity" version "3.18.2"
 }
 


### PR DESCRIPTION
This PR migrates the Geb project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this sets a projectId for use by Develocity.