### PR TITLE
Build a src distribution for releasing #245

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,14 +25,44 @@ To become a committer, you need to sign the [Apache Individual Contributor Agree
 ## Build Environment
 
 Geb builds with [Gradle](http://www.gradle.org/). 
-You do not need to have Gradle installed to work with the Geb build as Gradle provides an executable wrapper that you use to drive the build.
+You do not need to have Gradle installed to work with the Geb build as Gradle
+provides an executable wrapper that you use to drive the build.
 
 On UNIX type environments this is `gradlew` and is `gradlew.bat` on Windows.
+Most examples here are for UNIX type systems.
+You can leave off the leading `./` when using the wrapper on Windows.
 
-For example to run all the automated tests and quality checks for the entire project you would run…
+To see all available tasks you can run:
+
+    ./gradlew tasks
+
+But there are a few very common tasks worth knowing.
+For example, to run all the automated tests and quality
+checks for the entire project you would run:
 
     ./gradlew check
-    
+
+To publish Geb artifacts to your local Maven cache you would run:
+
+    ./gradlew publishToMavenLocal
+
+## Bootstrapping the build environment from a source distribution
+
+If you have cloned the source from the GitHub repo, you can skip this section. If instead
+you are using an ASF source release Zip, read on.
+
+ASF source releases don't contain binary files such as those needed by the Gradle wrapper.
+If using a source Zip release, there is an additional boostrap step you need to do
+to properly set up the build environment.
+
+The bootstrap step requires you to have a version of Gradle installed on your system.
+If you know the desired Gradle version, you can run Gradle's `wrapper` task.
+Alternatively, you can use the bootstrap project which knows about the correct Gradle version:
+
+    gradle -P bootstrap
+
+Now the wrapper will be installed, and you can follow the instructions elsewhere which use the wrapper.
+
 ## IDE import
 
 The project is set up to work with IntelliJ IDEA, simply import it using the native IntelliJ IDEA import for Gradle projects.

--- a/bootstrap/build.gradle
+++ b/bootstrap/build.gradle
@@ -1,0 +1,38 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+def props = new Properties()
+file("$projectDir/../gradle.properties").withInputStream {
+    props.load(it)
+}
+
+defaultTasks 'bootstrap'
+
+tasks.withType(Wrapper).configureEach {
+    gradleVersion = props.gradle_version
+}
+
+tasks.register('bootstrap') {
+    dependsOn 'wrapper'
+    doLast {
+        ant.move file: "${projectDir}/gradlew", todir: "${projectDir}/../"
+        ant.move file: "${projectDir}/gradlew.bat", todir: "${projectDir}/../"
+        ant.move file: "${projectDir}/gradle/wrapper", todir: "${projectDir}/../gradle/"
+    }
+}

--- a/buildSrc/src/main/groovy/geb.source-distribution.gradle
+++ b/buildSrc/src/main/groovy/geb.source-distribution.gradle
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+plugins {
+    id 'signing'
+}
+
+def srcSpec = copySpec {
+    from fileTree(rootProject.projectDir) {
+        exclude '.circleci', '.github', '.idea',
+            '**/build', '.asf.yaml', '.tm_properties',
+            'gradlew', 'gradlew.bat', 'gradle/wrapper', // gradlew
+            'out',             // used by Intellij IDEA
+            '**/*.iml',        // used by Intellij IDEA
+            '**/*.ipr',        // used by Intellij IDEA
+            '**/*.iws',        // used by Intellij IDEA
+            '.settings',       // used by Eclipse
+            '.classpath',      // used by Eclipse
+            '.gradle'          // used by Gradle
+    }
+}
+
+tasks.register('distSrc', Zip) {
+    archiveBaseName = 'apache-groovy-geb'
+    archiveAppendix = 'src'
+    into "groovy-geb-${project.version}"
+    with srcSpec
+}
+
+signing {
+    tasks.named('distSrc')
+}

--- a/geb.gradle
+++ b/geb.gradle
@@ -25,6 +25,7 @@ plugins {
     id 'geb.coordinates'
     alias(libs.plugins.nexusPublish)
     alias(libs.plugins.asl2)
+    id 'geb.source-distribution'
     id 'com.github.jk1.dependency-license-report' version '2.9'
     id 'org.nosphere.apache.rat'
     id 'com.github.ben-manes.versions' version '0.51.0'
@@ -100,6 +101,7 @@ tasks.named('rat') {
         'doc', // TODO re-enable checking for docs
         'logo.svg', // Logo svg
         'out/**', '*.ipr', '**/*.iml', '*.iws', '.idea/**', // Intellij files
+        'bootstrap/settings.gradle', // empty file
     ]
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@
 
 org.gradle.caching=true
 #org.gradle.caching.debug=true
+gradle_version=8.12


### PR DESCRIPTION
Builds a  source zip suitable for releasing.

ASF release policy requires source releases have no binary files, so the gradle wrapper is excluded. It can easily be added back in using the `wrapper` task or the `bootstrap` project.