### PR TITLE
link to apache/groovy-geb not geb/geb

### DIFF
--- a/doc/site/src/ratpack/templates/main.html
+++ b/doc/site/src/ratpack/templates/main.html
@@ -47,9 +47,9 @@
                         <a class="manuals item">Manual</a>
                         <a class="apis item">API</a>
                         <a class="mailing-lists item">Mailing Lists</a>
-                        <a class="item" href="http://github.com/geb/geb"><i class="github icon"></i> Code</a>
-                        <a class="item" href="https://github.com/geb/issues/issues"><i class="github icon"></i> Issues</a>
                         <a class="item" href="http://twitter.com/GebFramework"><i class="twitter icon"></i>Twitter</a>
+                        <a class="item" href="https://github.com/apache/groovy-geb"><i class="github icon"></i> Code</a>
+                        <a class="item" href="https://github.com/apache/groovy-geb/issues"><i class="github icon"></i> Issues</a>
                     </div>
                 </div>
 


### PR DESCRIPTION
Updates github links to repository within the apache Github Organization.