### PR TITLE
Add a few more GitHub actions to replace some CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,34 +15,6 @@
 
 version: 2
 jobs:
-  check:
-    docker:
-      - image: eclipse-temurin:21-jdk
-    resource_class: large
-    environment:
-      GRADLE_OPTS: -Xmx1024m -XX:MaxMetaspaceSize=256m
-      GRADLE_USER_HOME: .gradle-home
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - gradle-home-check-{{ .Branch }}
-            - gradle-home-check-master
-            - gradle-home-check
-      - run: ./gradlew --no-daemon --max-workers 4 --parallel -Pci module:check internal:check integration:check doc:site:check --continue
-      - run:
-          name: Copy all test results to a directory
-          command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
-      - store_test_results:
-          path: ~/test-results/
-      - store_artifacts:
-          path: build/reports
-      - save_cache:
-          key: gradle-home-check-{{ .Branch }}-{{ epoch }}
-          paths:
-            - .gradle-home
   manual:
     docker:
       - image: selenium/standalone-firefox
@@ -103,30 +75,6 @@ jobs:
           path: build/reports
       - save_cache:
           key: gradle-home-dockerised-crossbrowser-{{ .Branch }}-{{ epoch }}
-          paths:
-            - .gradle-home
-  local-cross-browser:
-    docker:
-      - image: selenium/standalone-chromium
-    resource_class: large
-    environment:
-        GRADLE_OPTS: -Xmx1024m -XX:MaxMetaspaceSize=256m
-        GRADLE_USER_HOME: .gradle-home
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - gradle-home-local-crossbrowser-{{ .Branch }}
-            - gradle-home-local-crossbrowser-master
-            - gradle-home-local-crossbrowser
-      - run: ./gradlew --no-daemon --max-workers 4 --parallel -p module -Pci localChromeTest
-      - run: *collectTestResults
-      - store_test_results:
-          path: ~/test-results/
-      - store_artifacts:
-          path: build/reports
-      - save_cache:
-          key: gradle-home-local-crossbrowser-{{ .Branch }}-{{ epoch }}
           paths:
             - .gradle-home
   saucelabs:

--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check documentation build
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17, 21]
+    runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build and run tests
+        run: ./gradlew --parallel -Pci --no-daemon :doc:manual:build -x rat # rat in separate workflow for fast feedback
+        timeout-minutes: 5
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-reports-${{ matrix.java }}
+          path: '**/build/reports/'

--- a/.github/workflows/dockerised-cross-browser.yml
+++ b/.github/workflows/dockerised-cross-browser.yml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run all browser tests in docker environment
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17, 21]
+    runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build and run tests
+        run: ./gradlew --no-daemon --max-workers 4 --parallel -Pci allDockerisedCrossBrowserTests -x rat # rat in separate workflow for fast feedback
+        timeout-minutes: 60
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-reports-${{ matrix.java }}
+          path: '**/build/reports/'

--- a/.github/workflows/local-browser.yml
+++ b/.github/workflows/local-browser.yml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run local browser tests
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17, 21]
+    runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build and run tests
+        run: ./gradlew --no-daemon --max-workers 4 --parallel -p module -Pci localChromeTest -x rat # rat in separate workflow for fast feedback
+        timeout-minutes: 60
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-reports-${{ matrix.java }}
+          path: '**/build/reports/'


### PR DESCRIPTION
Following the [discussion with @paulk-asert](https://github.com/apache/groovy-geb/issues/213#issuecomment-2675418754), I started going through the remaining actions on CircleCI to see about moving them over to GitHub Actions or Jenkins.

This removes the easy-to-reach ones. The remaining few will require some secrets management, as they require API keys to BrowserStack, SauceLabs, or LambdaTest.

I've got access to those via the Geb org that Marcin shared with me when handing things over.

Maintaining [Geb's integration with those providers](https://gebish.org/manual/current/#cloud-browser-testing) will require setting those up as shared secrets. I don't appear to have access to do that in GitHub like I did for the geb organization (https://github.com/organizations/geb/settings/secrets/actions).

I could probably get that done with a request to Apache Infra, for either GH Actions or Jenkins. If we do that, we can completely remove the CircleCI build.

I went ahead and used the build cache on the new files. I'm trusting that the Gradle tasks are deterministic enough that we needn't re-run them (see, e.g. https://blog.gradle.org/stop-rerunning-tests).