### PR TITLE
Fix a race-condition in reporting with parallel execution

### DIFF
--- a/module/geb-core/src/main/groovy/geb/test/GebTestManager.groovy
+++ b/module/geb-core/src/main/groovy/geb/test/GebTestManager.groovy
@@ -97,6 +97,11 @@ class GebTestManager {
         this.testClass.get().push(testClass)
         currentTestName.set(testName)
         if (reportingEnabled) {
+            // it happens that beforeTestClass for test class A is run on a thread
+            // and next beforeTest (and thus test execution) for tests from class B are run on that thread
+            // as the browser is thread-local reused, we need to set the report group here or the report
+            // eventually is written to the wrong report group which is confusing and makes some tests flaky
+            getBrowser().reportGroup(testClass)
             testCounter.get().push(nextTestCounter(testClass))
             perTestReportCounter.get().push(1)
         }


### PR DESCRIPTION
Without this PR the parallel execution tests failed one to many times
when executing them 10 times in a row due to wrong report group being used.

With this PR this race condition is fixed and it did not fail in the 500 runs
I made to verify, as I don't see how to write a reproducible test case for this situation.

Partly fixes #188 