### PR TITLE
Update references to old site to new site

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 Geb (pronounced “jeb”) is a browser automation solution. It brings together the power of WebDriver, the elegance of jQuery content selection, the robustness of Page Object modelling and the expressiveness of the Groovy language.
 
-For more information about the project, see the [http://www.gebish.org](http://www.gebish.org/).
+For more information about the project, see the [http://groovy.apache.org/geb/](http://groovy.apache.org/geb//).
 
 ## How to contribute
 

--- a/buildSrc/src/main/groovy/geb.base.gradle
+++ b/buildSrc/src/main/groovy/geb.base.gradle
@@ -118,6 +118,6 @@ tasks.withType(Groovydoc).configureEach {
 
     def docName = project.name == "manual" ? "Geb" : project.name
     docTitle = "Groovy API Documentation for $docName $version"
-    footer = "<p style='text-align: center'>Groovy API Documentation for $docName $version - Licensed under the Apache License, Version 2.0 - <a href='http://www.gebish.org'>http://www.gebish.org</a></p>"
+    footer = "<p style='text-align: center'>Groovy API Documentation for $docName $version - Licensed under the Apache License, Version 2.0 - <a href='http://groovy.apache.org/geb/'>http://groovy.apache.org/geb/</a></p>"
     windowTitle = "Groovy API for $docName $version"
 }

--- a/buildSrc/src/main/groovy/geb.publishing.gradle
+++ b/buildSrc/src/main/groovy/geb.publishing.gradle
@@ -33,7 +33,7 @@ signing {
 publishing {
     publications.configureEach {
         pom {
-            url = "http://www.gebish.org"
+            url = "http://groovy.apache.org/geb/"
             inceptionYear = "2010"
             licenses {
                 license {

--- a/doc/manual-snippets/real-browser/src/test/groovy/intro/ScriptingSpec.groovy
+++ b/doc/manual-snippets/real-browser/src/test/groovy/intro/ScriptingSpec.groovy
@@ -31,7 +31,7 @@ class ScriptingSpec extends Specification {
         expect:
         // tag::inline[]
         Browser.drive {
-            go "http://gebish.org"
+            go "http://groovy.apache.org/geb/"
 
             assert title == "Geb - Very Groovy Browser Automation" // <1>
 

--- a/doc/manual-snippets/real-browser/src/test/groovy/intro/page/GebHomePage.groovy
+++ b/doc/manual-snippets/real-browser/src/test/groovy/intro/page/GebHomePage.groovy
@@ -25,7 +25,7 @@ import intro.module.ManualsMenuModule
 
 // tag::class[]
 class GebHomePage extends Page {
-    static url = "http://gebish.org" //<5>
+    static url = "http://groovy.apache.org/geb/" //<5>
 
     static at = { title == "Geb - Very Groovy Browser Automation" } //<6>
 

--- a/doc/manual-snippets/real-browser/src/test/groovy/javascript/JQuerySupportSpec.groovy
+++ b/doc/manual-snippets/real-browser/src/test/groovy/javascript/JQuerySupportSpec.groovy
@@ -50,7 +50,7 @@ class JQuerySupportSpec extends GebSpecWithServerUsingJavascript {
                         </head>
                         <body>
                             <div id="a"></div>
-                            <div id="b" style="display:none;"><a href="http://www.gebish.org">Geb!</a></div>
+                            <div id="b" style="display:none;"><a href="http://groovy.apache.org/geb/">Geb!</a></div>
                         </body>
                     </html>
                     // end::html[]

--- a/doc/manual-snippets/src/test/groovy/browser/WithNewWindowSpec.groovy
+++ b/doc/manual-snippets/src/test/groovy/browser/WithNewWindowSpec.groovy
@@ -27,7 +27,7 @@ class WithNewWindowSpec extends DriveMethodSupportingSpecWithServer {
         given:
         server.responseHtml """
             // tag::html[]
-            <a href="http://www.gebish.org" target="_blank">Geb</a>
+            <a href="http://groovy.apache.org/geb/" target="_blank">Geb</a>
             // end::html[]
         """
 

--- a/doc/manual-snippets/src/test/groovy/browser/WithWindowSpec.groovy
+++ b/doc/manual-snippets/src/test/groovy/browser/WithWindowSpec.groovy
@@ -27,7 +27,7 @@ class WithWindowSpec extends DriveMethodSupportingSpecWithServer {
         given:
         server.responseHtml """
             // tag::using_name_html[]
-            <a href="http://www.gebish.org" target="myWindow">Geb</a>
+            <a href="http://groovy.apache.org/geb/" target="myWindow">Geb</a>
             // end::using_name_html[]
         """
 
@@ -47,7 +47,7 @@ class WithWindowSpec extends DriveMethodSupportingSpecWithServer {
         given:
         server.responseHtml """
             // tag::using_closure_html[]
-            <a href="http://www.gebish.org" target="_blank">Geb</a>
+            <a href="http://groovy.apache.org/geb/" target="_blank">Geb</a>
             // end::using_closure_html[]
         """
 

--- a/doc/manual-snippets/src/test/groovy/modules/UrlInputSnippetSpec.groovy
+++ b/doc/manual-snippets/src/test/groovy/modules/UrlInputSnippetSpec.groovy
@@ -38,12 +38,12 @@ class UrlInputSnippetSpec extends GebSpecWithCallbackServer {
         when:
         // tag::example[]
         def input = $(name: "homepage").module(UrlInput)
-        input.text = "http://gebish.org"
+        input.text = "http://groovy.apache.org/geb/"
 
         // end::example[]
         then:
         // tag::example[]
-        assert input.text == "http://gebish.org"
+        assert input.text == "http://groovy.apache.org/geb/"
         // end::example[]
     }
 

--- a/doc/manual-snippets/src/test/groovy/pages/AdvancedNavigationSpec.groovy
+++ b/doc/manual-snippets/src/test/groovy/pages/AdvancedNavigationSpec.groovy
@@ -28,12 +28,12 @@ class AdvancedNavigationSpec extends Specification {
     def "using to with page specifying an url"() {
         expect:
         // tag::to[]
-        Browser.drive(baseUrl: "https://gebish.org/") {
+        Browser.drive(baseUrl: "https://groovy.apache.org/geb/") {
             // end::to[]
             driver.javascriptEnabled = false
             // tag::to[]
             to PageObjectsPage
-            assert currentUrl == "https://gebish.org/pages"
+            assert currentUrl == "https://groovy.apache.org/geb/pages"
         }
         // end::to[]
     }
@@ -41,12 +41,12 @@ class AdvancedNavigationSpec extends Specification {
     def "using to with additional arguments"() {
         expect:
         // tag::to_with_args[]
-        Browser.drive(baseUrl: "https://gebish.org/") {
+        Browser.drive(baseUrl: "https://groovy.apache.org/geb/") {
             // end::to_with_args[]
             driver.javascriptEnabled = false
             // tag::to_with_args[]
-            to ManualsPage, "0.9.3", "index.html"
-            assert currentUrl == "https://gebish.org/manual/0.9.3/index.html"
+            to ManualsPage, "7.0.0", "index.html"
+            assert currentUrl == "https://groovy.apache.org/geb/manual/7.0.0/index.html"
         }
         // end::to_with_args[]
     }
@@ -54,17 +54,17 @@ class AdvancedNavigationSpec extends Specification {
     def "using to with custom convert to path"() {
         when:
         // tag::convert_to_path[]
-        def someManualVersion = new Manual(version: "0.9.3")
+        def someManualVersion = new Manual(version: "7.0.0")
 
         // end::convert_to_path[]
         then:
         // tag::convert_to_path[]
-        Browser.drive(baseUrl: "https://gebish.org/") {
+        Browser.drive(baseUrl: "https://groovy.apache.org/geb/") {
             // end::convert_to_path[]
             driver.javascriptEnabled = false
             // tag::convert_to_path[]
             to ManualsPage, someManualVersion
-            assert currentUrl == "https://gebish.org/manual/0.9.3/index.html"
+            assert currentUrl == "https://groovy.apache.org/geb/manual/7.0.0/index.html"
         }
         // end::convert_to_path[]
     }
@@ -72,17 +72,17 @@ class AdvancedNavigationSpec extends Specification {
     def "using to with named params"() {
         when:
         // tag::to_with_named_params[]
-        def someManualVersion = new Manual(version: "0.9.3")
+        def someManualVersion = new Manual(version: "7.0.0")
 
         // end::to_with_named_params[]
         then:
         // tag::to_with_named_params[]
-        Browser.drive(baseUrl: "https://gebish.org/") {
+        Browser.drive(baseUrl: "https://groovy.apache.org/geb/") {
             // end::to_with_named_params[]
             driver.javascriptEnabled = false
             // tag::to_with_named_params[]
             to ManualsPage, someManualVersion, flag: true
-            assert currentUrl == "https://gebish.org/manual/0.9.3/index.html?flag=true"
+            assert currentUrl == "https://groovy.apache.org/geb/manual/7.0.0/index.html?flag=true"
         }
         // end::to_with_named_params[]
     }
@@ -90,12 +90,12 @@ class AdvancedNavigationSpec extends Specification {
     def "using to with fragments"() {
         expect:
         // tag::to_with_fragment[]
-        Browser.drive(baseUrl: "https://gebish.org/") {
+        Browser.drive(baseUrl: "https://groovy.apache.org/geb/") {
             // end::to_with_fragment[]
             driver.javascriptEnabled = false
             // tag::to_with_fragment[]
-            to ManualsPage, UrlFragment.of("advanced-page-navigation"), "0.9.3", "index.html"
-            assert currentUrl == "https://gebish.org/manual/0.9.3/index.html#advanced-page-navigation"
+            to ManualsPage, UrlFragment.of("advanced-page-navigation"), "7.0.0", "index.html"
+            assert currentUrl == "https://groovy.apache.org/geb/manual/7.0.0/index.html#advanced-page-navigation"
         }
         // end::to_with_fragment[]
     }
@@ -103,12 +103,12 @@ class AdvancedNavigationSpec extends Specification {
     def "using to with parameterized page"() {
         expect:
         // tag::to_with_parameterized_page[]
-        Browser.drive(baseUrl: "https://gebish.org/") {
+        Browser.drive(baseUrl: "https://groovy.apache.org/geb/") {
             // end::to_with_parameterized_page[]
             driver.javascriptEnabled = false
             // tag::to_with_parameterized_page[]
-            to new ParameterizedManualsPage(version: "0.9.3", section: "advanced-page-navigation")
-            assert currentUrl == "https://gebish.org/manual/0.9.3/index.html#advanced-page-navigation"
+            to new ParameterizedManualsPage(version: "7.0.0", section: "advanced-page-navigation")
+            assert currentUrl == "https://groovy.apache.org/geb/manual/7.0.0/index.html#advanced-page-navigation"
         }
         // end::to_with_parameterized_page[]
     }

--- a/doc/manual-snippets/src/test/groovy/reporting/ReportingSpec.groovy
+++ b/doc/manual-snippets/src/test/groovy/reporting/ReportingSpec.groovy
@@ -55,7 +55,7 @@ class ReportingSpec extends DriveMethodSupportingSpecWithServer {
 
             // tag::reporting_groups[]
             reportGroup "geb"
-            go "http://gebish.org"
+            go "http://groovy.apache.org/geb/"
             report "home page"
             // end::reporting_groups[]
             assert new File(config.reportsDir, "geb/home page.html").exists()

--- a/doc/manual/manual.gradle
+++ b/doc/manual/manual.gradle
@@ -94,7 +94,7 @@ asciidoctorj {
         'selenium-version'     : libs.versions.selenium.get(),
         'groovy-version'       : libs.versions.groovy.get(),
         'sauce-connect-version': libs.versions.sauceConnect.get(),
-        'home-page'            : 'www.gebish.org',
+        'home-page'            : 'groovy.apache.org/geb/',
         docinfo1               : true,
         linkcss                : true,
         stylesheet             : 'css/style.css',

--- a/doc/manual/src/docs/asciidoc/120-build-integrations.adoc
+++ b/doc/manual/src/docs/asciidoc/120-build-integrations.adoc
@@ -62,7 +62,7 @@ Below is a valid `pom.xml` file for working with Geb for testing (with Spock).
   <packaging>jar</packaging>
   <version>1</version>
   <name>Geb Maven Example</name>
-  <url>http://www.gebish.org</url>
+  <url>http://groovy.apache.org/geb/</url>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/doc/manual/src/docs/asciidoc/140-project.adoc
+++ b/doc/manual/src/docs/asciidoc/140-project.adoc
@@ -1,6 +1,6 @@
 = About the project
 
-The Geb home page can be found at link:http://www.gebish.org[http://www.gebish.org].
+The Geb home page can be found at link:https://groovy.apache.org/geb/[https://groovy.apache.org/geb/].
 
 == API reference
 

--- a/integration/geb-gradle/geb-gradle.gradle
+++ b/integration/geb-gradle/geb-gradle.gradle
@@ -40,7 +40,7 @@ dependencies {
 }
 
 gradlePlugin {
-    website = "https://gebish.org/manual/current/#gradle-plugins"
+    website = "https://groovy.apache.org/geb/manual/current/#gradle-plugins"
     vcsUrl = "https://github.com/geb/geb"
 }
 

--- a/module/geb-core/src/test/groovy/geb/BrowserSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/BrowserSpec.groovy
@@ -44,13 +44,13 @@ class BrowserSpec extends GebSpecWithCallbackServer {
         go()
 
         when:
-        browser.clearCookies('http://gebish.org')
+        browser.clearCookies('http://groovy.apache.org/geb/')
 
         then:
         notThrown(Throwable)
 
         and:
-        browser.currentUrl.contains('gebish.org')
+        browser.currentUrl.contains('groovy.apache.org/geb/')
     }
 
     def "load default config"() {

--- a/module/geb-core/src/test/groovy/geb/navigator/FindAndFilterNavigatorSpec.groovy
+++ b/module/geb-core/src/test/groovy/geb/navigator/FindAndFilterNavigatorSpec.groovy
@@ -47,7 +47,7 @@ class FindAndFilterNavigatorSpec extends GebSpecWithCallbackServer {
         html {
             div(id: "idA", 'class': 'classA', "a")
             div(id: "idB", 'class': 'classB', "b")
-            a(id: "link", 'href': 'www.gebish.org', "Geb testing")
+            a(id: "link", 'href': 'groovy.apache.org/geb/', "Geb testing")
         }
 
         expect:


### PR DESCRIPTION
This should fix the test failures (kudos to @Vampire for spotting them) caused by redirecting traffic from redirecting traffic from gebish.org to groovy.apache.org/geb. See https://issues.apache.org/jira/browse/INFRA-26562 and https://github.com/apache/groovy-geb/issues/208 for more context.