### PR TITLE
Prep for release

### DIFF
--- a/buildSrc/src/main/groovy/geb.published-groovy-module.gradle
+++ b/buildSrc/src/main/groovy/geb.published-groovy-module.gradle
@@ -54,3 +54,7 @@ publishing {
         }
     }
 }
+
+tasks.register("publishJarsAndManual") {
+    dependsOn 'publishMainPublicationToApacheRepository'
+}

--- a/buildSrc/src/main/groovy/geb.publishing.gradle
+++ b/buildSrc/src/main/groovy/geb.publishing.gradle
@@ -47,14 +47,16 @@ publishing {
             }
             developers {
                 developer {
-                    id = "alkemist"
-                    name = "Luke Daley"
-                    roles = ["Founder"]
+                    id = "paulk-asert"
+                    name = "Paul King"
                 }
                 developer {
-                    id = "erdi"
-                    name = "Marcin Erdmann"
-                    roles = ["Lead"]
+                    id = "jonnybot"
+                    name = "Jonny Carter"
+                }
+                developer {
+                    id = "sdelamo"
+                    name = " Sergio del Amo"
                 }
             }
         }

--- a/buildSrc/src/main/groovy/geb.publishing.gradle
+++ b/buildSrc/src/main/groovy/geb.publishing.gradle
@@ -56,7 +56,7 @@ publishing {
                 }
                 developer {
                     id = "sdelamo"
-                    name = " Sergio del Amo"
+                    name = "Sergio del Amo"
                 }
             }
         }

--- a/integration/geb-gradle/geb-gradle.gradle
+++ b/integration/geb-gradle/geb-gradle.gradle
@@ -41,7 +41,7 @@ dependencies {
 
 gradlePlugin {
     website = "https://groovy.apache.org/geb/manual/current/#gradle-plugins"
-    vcsUrl = "https://github.com/geb/geb"
+    vcsUrl = "https://github.com/apache/groovy-geb"
 }
 
 apply from: 'plugin-definitions.gradle'


### PR DESCRIPTION
Doing some work here to prepare for the 8.0 release.

The big change here is that the `publishJarsAndManual` task had been removed from most of the modules by f2a951fb53f73700df4c3b4a613b8c67369715f. I suspect this was inadvertent. 

The result of this was that while our snapshot build was running, it wasn't actually publishing anything. See https://ci-builds.apache.org/job/Groovy/job/Geb%20snapshot%20build/lastBuild/console and the publication dates at https://repository.apache.org/content/repositories/snapshots/org/apache/groovy/geb/ for confirmation of this. I did a local test publication of the [geb-waiting module](https://repository.apache.org/content/repositories/snapshots/org/apache/groovy/geb/geb-waiting/) to verify that this change worked correctly. Compare the results of `./gradlew publishJarsAndManual --dry-run` with master for further confirmation.

I've also updated the developer list. I included @paulk-asert, @sdelamo, and myself for now, though we may wish to update this soonish. I tried to think, "Who should be contacted about this project?" as the way to clarify the choice.

I toyed around with [publishing maven package relocation information](https://docs.gradle.org/8.14.3/userguide/publishing_maven.html#publishing_maven:relocation) for the old org.gebish coordinates. I got a 403 trying to write to the org.gebish package in Apache's nexus repository. I imagine we could still build this POM and publish it to central, but we may need to go another route.