### PR TITLE
Update Release notes to use verification scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out
 *.hprof
 .pnpm-store/
 **/tags
+etc/bin/results

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,12 +44,18 @@ limitations under the License.
 11. `git push` the version branch and tag to GitHub
 12. `read -s APACHE_PW` and enter your password at the prompt
 13. Run `./gradlew --no-build-cache publishJarsAndManual -x :integration:geb-gradle:publishPlugins -PapacheUser=jonnybot -PapachePassword="${APACHE_PW}"`
-14. Start the vote process on the groovy-dev mailing list. It will need at least 72 hours of remaining open and receive at least three affirmative votes from the Groovy PMC. See the [Apache Voting process](https://www.apache.org/foundation/voting.html) for more detail. Mention significant breaking changes if there are any.
-15. Assuming the vote passes (at least three +1 votes from the PMC), you can take the following steps to finalize the release.
-16. Email the vote thread to note that the vote has passed, with a final tally of the votes.
-17. Ask a member of the PMC to copy the artifacts from the staging directory in subversion to `groovy-release/geb/${VERSION}` and commit them to subversion, as above.
-18. Ask a member of the PMC to release the staging repository at https://repository.apache.org/#stagingRepositories
-19. Release the Gradle plugins with `./gradlew :integration:geb-gradle:publishPlugins`
+14. Verify the staged release. Run the automated verification script from the project root:
+    ```bash
+    etc/bin/verify.sh dev «version» /tmp/geb-«version»-verify
+    ```
+    This downloads the staged artifacts, verifies checksums and GPG signatures, checks for required files, and runs the RAT license audit. The individual scripts in `etc/bin/` can also be run separately — see their header comments for details.
+15. Verify the build is reproducible per [ASF Security policy](https://cwiki.apache.org/confluence/display/SECURITY/Reproducible+Builds) by running `etc/bin/test-reproducible-builds.sh`; this will run the build twice to ensure that the built outputs are identical.
+16. Start the vote process on the groovy-dev mailing list. It will need at least 72 hours of remaining open and receive at least three affirmative votes from the Groovy PMC. See the [Apache Voting process](https://www.apache.org/foundation/voting.html) for more detail. Mention significant breaking changes if there are any.
+17. Assuming the vote passes (at least three +1 votes from the PMC), you can take the following steps to finalize the release.
+18. Email the vote thread to note that the vote has passed, with a final tally of the votes.
+19. Ask a member of the PMC to copy the artifacts from the staging directory in subversion to `groovy-release/geb/${VERSION}` and commit them to subversion, as above.
+20. Ask a member of the PMC to release the staging repository at https://repository.apache.org/#stagingRepositories
+21. Release the Gradle plugins with `./gradlew :integration:geb-gradle:publishPlugins`
 
 # Post-release actions
 1. Bump the version to a snapshot of the next planned version.
@@ -58,11 +64,11 @@ limitations under the License.
 4. Commit with message 'Begin version «version»'
 5. Push (make sure you push the tag as well).
 6. Merge the release branch back into the master branch.
-6. Bump Geb versions in example projects: 
+6. Bump Geb versions in example projects:
     * [geb-example-gradle](https://github.com/geb/geb-example-gradle)
     * [geb-example-maven](https://github.com/geb/geb-example-maven)
 7. Update issues and milestones in GitHub tracker:
     * Find all unresolved issues in the tracker that have the fix version set to the recently released version and bulk edit them to have the fix version set to the next version.
     * Find the recently released milestone, change the version number if it's different from the one that was released and close it.
 8. Wait for the build of the next version to pass and the site including manual for the released version to be published.
-9. Send an email to the mailing list announcing the release. You can use [this one]() as a template. 
+9. Send an email to the mailing list announcing the release. You can use [this one]() as a template.

--- a/etc/bin/download-release-artifacts.sh
+++ b/etc/bin/download-release-artifacts.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+#
+# download-release-artifacts.sh - Download Geb release artifacts from dist.apache.org.
+#
+# Fetches the source distribution zip, its GPG signature (.asc), and checksum
+# files (.sha256, .sha512) into a local directory for offline verification.
+#
+# Artifacts are downloaded from:
+#   https://dist.apache.org/repos/dist/{dev|release}/groovy/geb/<version>/
+#
+# Usage:
+#   download-release-artifacts.sh <dev|release> <version> [download-dir]
+#
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 ['dev' or 'release'] [semantic.version] <optional download location>"
+  exit 1
+fi
+
+PROJECT_NAME='groovy-geb'
+DIST_TYPE=$1
+VERSION=$2
+DOWNLOAD_LOCATION="${3:-downloads}"
+
+if [[ "${DIST_TYPE}" != "dev" && "${DIST_TYPE}" != "release" ]]; then
+  echo "Error: DIST_TYPE must be either 'dev' or 'release', got '${DIST_TYPE}'"
+  echo "Usage: $0 ['dev' or 'release'] [version] <optional download location>"
+  exit 1
+fi
+
+VERSION=${VERSION#v} # in case someone prefixes a v
+
+echo "Downloading files to ${DOWNLOAD_LOCATION}"
+mkdir -p "${DOWNLOAD_LOCATION}/src"
+
+# Geb publishes a source distribution under the groovy dist area
+BASE_URL="https://dist.apache.org/repos/dist/${DIST_TYPE}/groovy/geb/${VERSION}"
+
+echo "Downloading source release files from ${BASE_URL} ..."
+curl -f -L -o "${DOWNLOAD_LOCATION}/src/apache-${PROJECT_NAME}-src-${VERSION}.zip" \
+  "${BASE_URL}/apache-${PROJECT_NAME}-src-${VERSION}.zip"
+curl -f -L -o "${DOWNLOAD_LOCATION}/src/apache-${PROJECT_NAME}-src-${VERSION}.zip.asc" \
+  "${BASE_URL}/apache-${PROJECT_NAME}-src-${VERSION}.zip.asc"
+curl -f -L -o "${DOWNLOAD_LOCATION}/src/apache-${PROJECT_NAME}-src-${VERSION}.zip.sha256" \
+  "${BASE_URL}/apache-${PROJECT_NAME}-src-${VERSION}.zip.sha256"
+curl -f -L -o "${DOWNLOAD_LOCATION}/src/apache-${PROJECT_NAME}-src-${VERSION}.zip.sha512" \
+  "${BASE_URL}/apache-${PROJECT_NAME}-src-${VERSION}.zip.sha512"
+
+echo "✅ Source release artifacts downloaded to ${DOWNLOAD_LOCATION}/src"

--- a/etc/bin/test-reproducible-builds.sh
+++ b/etc/bin/test-reproducible-builds.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+#
+# test-reproducible-builds.sh - Verify that the Geb build is reproducible.
+#
+# Required by ASF Security policy for projects that build/sign on CI:
+#   https://cwiki.apache.org/confluence/display/SECURITY/Reproducible+Builds
+#
+# Builds all jar artifacts twice from a clean state and compares SHA-256
+# checksums. SOURCE_DATE_EPOCH is set from the last git commit to ensure
+# timestamp-dependent outputs are deterministic.
+#
+# Any differing jars are preserved under etc/bin/results/ for inspection.
+# That directory is git-ignored.
+#
+# Must be run from within a Geb git checkout. Takes no arguments.
+#
+# Usage:
+#   etc/bin/test-reproducible-builds.sh
+#
+
+set -euo pipefail
+
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+
+CWD=$(pwd)
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "${SCRIPT_DIR}/../.."
+
+rm -rf "${SCRIPT_DIR}/results" || true
+mkdir -p "${SCRIPT_DIR}/results/first"
+mkdir -p "${SCRIPT_DIR}/results/second"
+
+echo "================================================================"
+echo " Testing Reproducible Builds for Apache Groovy Geb"
+echo " SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"
+echo "================================================================"
+echo ""
+
+echo "Cleaning project..."
+git clean -xdf --exclude='etc/bin' --exclude='.idea' --exclude='.gradle'
+
+echo ""
+echo "--- First build ---"
+./gradlew jar --rerun-tasks --no-build-cache
+find . -path ./etc -prune -o -type f -path '*/build/libs/*.jar' -print0 | while IFS= read -r -d '' f; do
+  shasum -a 256 "$f"
+done | sort > "${SCRIPT_DIR}/results/first.txt"
+find . -path ./etc -prune -o -type f -path '*/build/libs/*.jar' -print0 | xargs -0 -I{} cp --parents {} "${SCRIPT_DIR}/results/first/" 2>/dev/null || \
+  find . -path ./etc -prune -o -type f -path '*/build/libs/*.jar' -print0 | while IFS= read -r -d '' f; do
+    mkdir -p "${SCRIPT_DIR}/results/first/$(dirname "$f")"
+    cp "$f" "${SCRIPT_DIR}/results/first/$f"
+  done
+
+echo ""
+echo "--- Cleaning for second build ---"
+git clean -xdf --exclude='etc/bin' --exclude='.idea' --exclude='.gradle'
+
+echo ""
+echo "--- Second build ---"
+./gradlew jar --rerun-tasks --no-build-cache
+find . -path ./etc -prune -o -type f -path '*/build/libs/*.jar' -print0 | while IFS= read -r -d '' f; do
+  shasum -a 256 "$f"
+done | sort > "${SCRIPT_DIR}/results/second.txt"
+find . -path ./etc -prune -o -type f -path '*/build/libs/*.jar' -print0 | while IFS= read -r -d '' f; do
+    mkdir -p "${SCRIPT_DIR}/results/second/$(dirname "$f")"
+    cp "$f" "${SCRIPT_DIR}/results/second/$f"
+  done
+
+echo ""
+echo "--- Comparing builds ---"
+cd "${SCRIPT_DIR}/results"
+if diff -u first.txt second.txt > diff.txt 2>&1; then
+  echo "✅ All jar artifacts are identical between the two builds."
+  rm -f diff.txt
+else
+  echo "❌ Some jar artifacts differ between builds:"
+  cat diff.txt
+  echo ""
+  echo "Differing artifacts have been preserved in:"
+  echo "  ${SCRIPT_DIR}/results/first/"
+  echo "  ${SCRIPT_DIR}/results/second/"
+fi
+
+cd "$CWD"

--- a/etc/bin/verify-source-distribution.sh
+++ b/etc/bin/verify-source-distribution.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+#
+# verify-source-distribution.sh - Verify a downloaded Geb source distribution.
+#
+# Expects the download directory to contain SVN_KEYS (the Groovy project KEYS
+# file) and a src/ subdirectory with the zip, .asc, and .sha256 files, as
+# produced by download-release-artifacts.sh.
+#
+# Performs the following checks:
+#   1. SHA-256 checksum verification
+#   2. GPG signature verification (using an isolated temporary keyring)
+#   3. Extraction and presence of LICENSE, NOTICE, and README.md
+#
+# Usage:
+#   verify-source-distribution.sh <version> [download-dir]
+#
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 [semantic.version] <optional download location>"
+  exit 1
+fi
+
+VERSION=$1
+DOWNLOAD_LOCATION="$(cd "${2:-downloads}" && pwd)"
+
+VERSION=${VERSION#v} # in case someone prefixes a v
+
+cd "${DOWNLOAD_LOCATION}/src"
+ZIP_FILE="apache-groovy-geb-src-${VERSION}.zip"
+
+if [ ! -f "${ZIP_FILE}" ]; then
+  echo "Error: Could not find ${ZIP_FILE} in ${DOWNLOAD_LOCATION}/src"
+  exit 1
+fi
+
+export GEB_GPG_HOME=$(mktemp -d)
+cleanup() {
+  rm -rf "${GEB_GPG_HOME}"
+}
+trap cleanup EXIT
+
+echo "Verifying SHA-256 checksum..."
+EXPECTED_HASH=$(cat "${ZIP_FILE}.sha256" | awk '{print $1}' | tr -d '\r\n')
+ACTUAL_HASH=$(shasum -a 256 "${ZIP_FILE}" | awk '{print $1}')
+if [ "${EXPECTED_HASH}" != "${ACTUAL_HASH}" ]; then
+    echo "❌ SHA-256 checksum verification failed"
+    echo "  Expected: ${EXPECTED_HASH}"
+    echo "  Actual:   ${ACTUAL_HASH}"
+    exit 1
+fi
+echo "✅ SHA-256 Checksum Verified"
+
+echo "Importing GPG keys to independent GPG home ..."
+gpg --homedir "${GEB_GPG_HOME}" --import "${DOWNLOAD_LOCATION}/SVN_KEYS"
+echo "✅ GPG Keys Imported"
+
+echo "Verifying GPG signature..."
+gpg --homedir "${GEB_GPG_HOME}" --verify "${ZIP_FILE}.asc" "${ZIP_FILE}"
+echo "✅ GPG Signature Verified"
+
+SRC_DIR="groovy-geb-${VERSION}"
+
+if [ -d "${SRC_DIR}" ]; then
+  echo "Previous source directory found, removing..."
+  rm -rf "${SRC_DIR}"
+fi
+
+echo "Extracting zip file..."
+unzip -q "${ZIP_FILE}"
+
+if [ ! -d "${SRC_DIR}" ]; then
+  echo "Error: Expected extracted folder '${SRC_DIR}' not found."
+  exit 1
+fi
+
+echo "Checking for required files..."
+REQUIRED_FILES=("LICENSE" "NOTICE" "README.md")
+
+for FILE in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "${SRC_DIR}/${FILE}" ]; then
+    echo "❌ Missing required file: ${FILE}"
+    exit 1
+  fi
+  echo "✅ Found required file: ${FILE}"
+done
+
+echo "✅ All source distribution checks passed for Apache Groovy Geb ${VERSION}."

--- a/etc/bin/verify.sh
+++ b/etc/bin/verify.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+#
+# verify.sh - End-to-end release verification for Apache Groovy Geb.
+#
+# Downloads staged artifacts from dist.apache.org, verifies their checksums
+# and GPG signatures, checks for required files (LICENSE, NOTICE, README.md),
+# and runs the Apache RAT license audit against the extracted source.
+#
+# The individual steps are delegated to companion scripts in this directory:
+#   download-release-artifacts.sh  - fetches the source distribution and hashes
+#   verify-source-distribution.sh  - checks integrity, signatures, and contents
+#
+# Usage:
+#   verify.sh <dev|release> <version> [download-dir]
+#
+# Examples:
+#   verify.sh dev 8.0.1 /tmp/geb-verify   # verify a staging candidate
+#   verify.sh release 8.0.0               # verify a published release
+#
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 ['dev' or 'release'] [semantic.version] <optional download location>"
+  echo ""
+  echo "  Example: $0 dev 8.0.0 /tmp/geb-verify"
+  exit 1
+fi
+
+DIST_TYPE=$1
+VERSION=$2
+DOWNLOAD_LOCATION="${3:-downloads}"
+
+if [[ "${DIST_TYPE}" != "dev" && "${DIST_TYPE}" != "release" ]]; then
+  echo "Error: DIST_TYPE must be either 'dev' or 'release', got '${DIST_TYPE}'"
+  echo "Usage: $0 ['dev' or 'release'] [semantic.version] <optional download location>"
+  exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+VERSION=${VERSION#v} # in case someone prefixes a v
+
+cleanup() {
+  echo "❌ Verification failed. ❌"
+}
+trap cleanup ERR
+
+mkdir -p "${DOWNLOAD_LOCATION}"
+DOWNLOAD_LOCATION="$(cd "${DOWNLOAD_LOCATION}" && pwd)"
+
+echo "================================================================"
+echo " Verifying Apache Groovy Geb ${VERSION} (${DIST_TYPE})"
+echo "================================================================"
+echo ""
+
+echo "Downloading KEYS file ..."
+curl -f -L -o "${DOWNLOAD_LOCATION}/SVN_KEYS" "https://dist.apache.org/repos/dist/release/groovy/KEYS"
+echo "✅ KEYS Downloaded"
+echo ""
+
+echo "Downloading Artifacts ..."
+"${SCRIPT_DIR}/download-release-artifacts.sh" "${DIST_TYPE}" "${VERSION}" "${DOWNLOAD_LOCATION}"
+echo "✅ Artifacts Downloaded"
+echo ""
+
+echo "Verifying Source Distribution ..."
+"${SCRIPT_DIR}/verify-source-distribution.sh" "${VERSION}" "${DOWNLOAD_LOCATION}"
+echo "✅ Source Distribution Verified"
+echo ""
+
+echo "Using Java at ..."
+which java
+java -version
+echo ""
+
+PROJECT_ROOT="${SCRIPT_DIR}/../.."
+
+echo "Applying License Audit (RAT) ..."
+"${PROJECT_ROOT}/gradlew" -p "${DOWNLOAD_LOCATION}/src/groovy-geb-${VERSION}" rat
+echo "✅ RAT passed"
+echo ""
+
+echo "================================================================"
+echo " ✅✅✅ Automatic verification finished for Geb ${VERSION}."
+echo "================================================================"
+echo ""
+echo "The extracted source is available at:"
+echo "  ${DOWNLOAD_LOCATION}/src/groovy-geb-${VERSION}"
+echo ""
+echo "Next steps for manual verification:"
+echo "  1. Review the extracted source"
+echo "  2. Run the reproducible build test:"
+echo "       ${SCRIPT_DIR}/test-reproducible-builds.sh"
+echo "  ...which will build the project twice from the extracted source and compare jar checksums."


### PR DESCRIPTION
This adds a port of the release verification scripts that @cbmarcum created for Groovy (see https://lists.apache.org/thread/684b33z83fmycgm3sl2k4lh2dn668pf7) to Geb and updates the RELEASING.md files to match their use.

I have tested out the verification script (verify.sh) against the 8.0.1 release (see https://dist.apache.org/repos/dist/release/groovy/geb/8.0.1/) with this command: `etc/bin/verify.sh release 8.0.1`. I haven't rigorously tested fail states, though I can attest that the scripts do fail for non-existent releases in dev & release.

Part of the motivation here is to demonstrate to the ASF that we have a process for verifying releases as well as reproducible builds. With that, we should be able to setup a more automated release process, similar to what Grails has.

I would love for someone to test out the changes to the RELEASING.md docs in particular. I realize you may have to do a "dry run" of some of the steps, since you won't be running against a real release, but some validation that the new steps make sense to someone who isn't me would be appreciated. :) 