### PR TITLE
change the manual-snippets / real-browser test configuration to use a…

### DIFF
--- a/doc/manual-snippets/real-browser/src/test/resources/GebConfig.groovy
+++ b/doc/manual-snippets/real-browser/src/test/resources/GebConfig.groovy
@@ -16,7 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.firefox.FirefoxOptions
 import org.testcontainers.Testcontainers
 import org.testcontainers.containers.BrowserWebDriverContainer
 import org.testcontainers.utility.ResourceReaper
@@ -27,7 +27,7 @@ Testcontainers.exposeHostPorts(8080)
 
 driver = {
     def container = new BrowserWebDriverContainer<>()
-            .withCapabilities(new ChromeOptions())
+            .withCapabilities(new FirefoxOptions())
             .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.SKIP, null)
 
     container.start()


### PR DESCRIPTION
… Firefox container.

I'm using macOS arm64 and there is no native Selenium Chrome arm64 image so they fail for me when running locally.
[docker-selenium architectures](https://github.com/SeleniumHQ/docker-selenium?tab=readme-ov-file#browser-images-in-multi-arch).
This configuration would match the Geb-Testcontainers tests as well.
